### PR TITLE
Add dual stack `ip` and `ipAddress` codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,50 @@ cenc.decode(ipv6Address, buffer)
 // { host: '0:0:0:0:0:0:0:1', port: 8080 }
 ```
 
+### `ip`
+
+Codec for dual IPv4/6 addresses.
+
+> :warning: The codec is only defined for valid IPv4 and IPv6 addresses.
+
+```js
+const { ip } = require('compact-encoding-net')
+```
+
+#### Encoding
+
+```js
+const buffer = cenc.encode(ip, '::1')
+```
+
+#### Decoding
+
+```js
+cenc.decode(ip, buffer)
+// '0:0:0:0:0:0:0:1'
+```
+
+### `ipAddress`
+
+Codec for dual IPv4/6 addresses plus a port.
+
+```js
+const { ipAddress } = require('compact-encoding-net')
+```
+
+#### Encoding
+
+```js
+const buffer = cenc.encode(ipAddress, { host: '::1', port: 8080 })
+```
+
+#### Decoding
+
+```js
+cenc.decode(ipv6Address, buffer)
+// { host: '0:0:0:0:0:0:0:1', family: 6, port: 8080 }
+```
+
 ## License
 
 ISC

--- a/index.js
+++ b/index.js
@@ -113,10 +113,57 @@ const ipv6 = {
 
 const ipv6Address = address(ipv6)
 
+const ip = {
+  preencode (state, string) {
+    const family = string.includes(':') ? 6 : 4
+    c.uint8.preencode(state, family)
+    if (family === 4) ipv4.preencode(state)
+    else ipv6.preencode(state)
+  },
+  encode (state, string) {
+    const family = string.includes(':') ? 6 : 4
+    c.uint8.encode(state, family)
+    if (family === 4) ipv4.encode(state, string)
+    else ipv6.encode(state, string)
+  },
+  decode (state) {
+    const family = c.uint8.decode(state)
+    if (family === 4) return ipv4.decode(state)
+    else return ipv6.decode(state)
+  }
+}
+
+const ipAddress = {
+  preencode (state, m) {
+    const family = m.host.includes(':') ? 6 : 4
+    c.uint8.preencode(state, family)
+    if (family === 4) ipv4.preencode(state)
+    else ipv6.preencode(state)
+    port.preencode(state, m.port)
+  },
+  encode (state, m) {
+    const family = m.host.includes(':') ? 6 : 4
+    c.uint8.encode(state, family)
+    if (family === 4) ipv4.encode(state, m.host)
+    else ipv6.encode(state, m.host)
+    port.encode(state, m.port)
+  },
+  decode (state) {
+    const family = c.uint8.decode(state)
+    return {
+      host: family === 4 ? ipv4.decode(state) : ipv6.decode(state),
+      family,
+      port: port.decode(state)
+    }
+  }
+}
+
 module.exports = {
   port,
   ipv4,
   ipv4Address,
   ipv6,
-  ipv6Address
+  ipv6Address,
+  ip,
+  ipAddress
 }

--- a/index.js
+++ b/index.js
@@ -135,17 +135,11 @@ const ip = {
 
 const ipAddress = {
   preencode (state, m) {
-    const family = m.host.includes(':') ? 6 : 4
-    c.uint8.preencode(state, family)
-    if (family === 4) ipv4.preencode(state)
-    else ipv6.preencode(state)
+    ip.preencode(state, m.host)
     port.preencode(state, m.port)
   },
   encode (state, m) {
-    const family = m.host.includes(':') ? 6 : 4
-    c.uint8.encode(state, family)
-    if (family === 4) ipv4.encode(state, m.host)
-    else ipv6.encode(state, m.host)
+    ip.encode(state, m.host)
     port.encode(state, m.port)
   },
   decode (state) {

--- a/test.mjs
+++ b/test.mjs
@@ -1,7 +1,7 @@
 import test from 'brittle'
 import c from 'compact-encoding'
 
-import { port, ipv4, ipv6 } from './index.js'
+import { port, ipv4, ipv6, ip, ipAddress } from './index.js'
 
 test('port', (t) => {
   const p = 0x1234
@@ -67,4 +67,40 @@ test('ipv6', (t) => {
     t.alike(c.encode(ipv6, '::ABCD'), buf)
     t.alike(c.decode(ipv6, buf), '0:0:0:0:0:0:0:abcd')
   })
+})
+
+test('dual ip', (t) => {
+  {
+    const host = '1.2.3.4'
+
+    t.alike(c.decode(ip, c.encode(ip, host)), host, 'ipv4')
+  }
+  {
+    const host = '1:2:3:4:5:6:7:8'
+
+    t.alike(c.decode(ip, c.encode(ip, host)), host, 'ipv6')
+  }
+})
+
+test('dual ip + port', (t) => {
+  const port = 1234
+
+  {
+    const host = '1.2.3.4'
+
+    t.alike(c.decode(ipAddress, c.encode(ipAddress, { host, port })), {
+      host,
+      family: 4,
+      port
+    }, 'ipv4')
+  }
+  {
+    const host = '1:2:3:4:5:6:7:8'
+
+    t.alike(c.decode(ipAddress, c.encode(ipAddress, { host, port })), {
+      host,
+      family: 6,
+      port
+    }, 'ipv6')
+  }
 })


### PR DESCRIPTION
Uses an extra byte to encode the family, resulting in 5 byte IPv4 addresses and 17 byte IPv6 addresses. As in #1, the family is included in decoded address objects.