### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/compact-encoding/compact-encoding-net#readme",
   "dependencies": {
-    "compact-encoding": "^2.4.1"
+    "compact-encoding": "^3.0.0"
   },
   "devDependencies": {
     "brittle": "^3.16.3",


### PR DESCRIPTION
Doesn't use `buffer` so is a dependency bump.